### PR TITLE
Add the ability to remove ports

### DIFF
--- a/include/jackaudioio.hpp
+++ b/include/jackaudioio.hpp
@@ -205,6 +205,23 @@ In that method you can get audio in from jack and write it out to jack.
 				throw(std::runtime_error);
 
 			/**
+			   @brief Remove a jack input port from our client.
+			   This method cannot be called while the client is running.
+			  \param name string the name of the port to remove
+			  \return the number of total input ports
+			*/
+			virtual unsigned int removeInPort(std::string name)
+				throw(std::runtime_error);
+			/**
+			   @brief Remove a jack output port from our client.
+			   This method cannot be called while the client is running.
+			  \param name string the name of the port to remove
+			  \return the number of total output ports
+			*/
+			virtual unsigned int removeOutPort(std::string name)
+				throw(std::runtime_error);
+
+			/**
 			   @brief Connect our output to a jack client's source port.
 			  \param index the index of our output port to connect from.
 			  \param sourcePortName the client:port name to connect to


### PR DESCRIPTION
The client cannot be running when this is done, because then we may erase from the middle of `m{Input,Output}Ports` while `jackToClassAudioCallback` is getting the ports. There's probably a way to defer erasing the port so this can be worked around, but does anyone need to remove ports from a running client anyways?